### PR TITLE
Enable monasca-thresh to configure topology.max.spout.pending for Storm

### DIFF
--- a/thresh/src/main/java/monasca/thresh/infrastructure/thresholding/MetricSpout.java
+++ b/thresh/src/main/java/monasca/thresh/infrastructure/thresholding/MetricSpout.java
@@ -30,8 +30,11 @@ import org.apache.storm.tuple.Values;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.Thread;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 public class MetricSpout extends KafkaSpout {
   @SuppressWarnings("unchecked")
@@ -70,8 +73,11 @@ public class MetricSpout extends KafkaSpout {
     if (metric.dimensions == null) {
       metric.dimensions = EMPTY_DIMENSIONS;
     }
+    // get unique identifier, required for storm
+    final String uId = Long.toString(Thread.currentThread().getId()) +  Long.toString(ThreadLocalRandom.current().nextInt());
+
     collector.emit(new Values(new TenantIdAndMetricName(tenantId, metricEnvelope.metric
-        .definition().name), metricEnvelope.creationTime, metric));
+        .definition().name), metricEnvelope.creationTime, metric), uId);
   }
 
   @Override

--- a/thresh/src/main/java/monasca/thresh/infrastructure/thresholding/MetricSpout.java
+++ b/thresh/src/main/java/monasca/thresh/infrastructure/thresholding/MetricSpout.java
@@ -74,7 +74,8 @@ public class MetricSpout extends KafkaSpout {
       metric.dimensions = EMPTY_DIMENSIONS;
     }
     // get unique identifier, required for storm
-    final String uId = Long.toString(Thread.currentThread().getId()) +  Long.toString(ThreadLocalRandom.current().nextInt());
+    final String uId = Long.toString(Thread.currentThread().getId())
+                       + Long.toString(ThreadLocalRandom.current().nextInt());
 
     collector.emit(new Values(new TenantIdAndMetricName(tenantId, metricEnvelope.metric
         .definition().name), metricEnvelope.creationTime, metric), uId);


### PR DESCRIPTION
topology.max.spout.pending allows to limit the number of concurrent
entries sent from spout to worker(s). However, this requires the
usage of a unique id when sending messages (emit).

Story: 2005471
Task: 30550